### PR TITLE
Remove spot instance config as Healthomics does not support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ aws omics get-run-task --id ${WORKFLOW_RUN_ID} --task-id <TASK_ID> --profile <YO
 ## Cost Optimization
 
 - Use appropriate instance types based on your data size and processing requirements
-- Consider using Spot instances for cost savings (configure in parameter templates)
 - Implement workflow caching to avoid re-running completed tasks
 - Monitor resource utilization and adjust instance types accordingly
 


### PR DESCRIPTION
*Issue #*: N/A

*Description of changes*:

Removed the suggestion to switch to spot instance usage, as Healthomics does not support running on spot instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
